### PR TITLE
Change Nix API to expose FFI jar

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,7 @@
 { }:
 let
-  ffiPath = (import ./ffi/default.nix {}).java_ffi;
+  ffi = (import ./ffi/default.nix {}).ffi;  
 in {
-  inherit (import ./sdk/default.nix { inherit ffiPath; }) sdk java_sdk docs;
+  inherit ffi;
+  inherit (import ./sdk/default.nix { inherit ffi; }) sdk docs;
 }

--- a/ffi/default.nix
+++ b/ffi/default.nix
@@ -75,7 +75,6 @@ let
 
 in {
   inherit ffi;
-  java_ffi = "${ffi}/lib";
 
   gradleUpdateScript = pkgs.writeShellScript "generate_gradle_lock_file" ''
     export JAVA_HOME=${pkgs.jdk21}

--- a/sdk/default.nix
+++ b/sdk/default.nix
@@ -1,4 +1,4 @@
-{ ffiPath ? (import ./../ffi/default.nix {}).java_ffi
+{ ffi ? (import ./../ffi/default.nix {}).ffi
 }:
 let
   pkgs = import (builtins.fetchTarball {
@@ -57,7 +57,7 @@ let
 
         # copy the ffi jar into src/libs/antithesis-ffi-1.3.0.jar
         mkdir -p libs
-        cp -R ${ffiPath}/*.jar libs
+        cp -R ${ffi}/lib/*.jar libs
 
         runHook postUnpack
       '';
@@ -73,7 +73,6 @@ let
 
 in {
   inherit sdk;
-  java_sdk = "${sdk}/lib";
   docs = "${sdk}/docs";
 
   gradleUpdateScript = pkgs.writeShellScript "generate_gradle_lock_file" ''


### PR DESCRIPTION
Expose the FFI jar and stop creating load-bearing derived strings.

nix-build remains happy. 