### PR TITLE
Hide coverage implementation details from the SDK

### DIFF
--- a/ffi/src/main/java/com/antithesis/ffi/internal/FfiHandler.java
+++ b/ffi/src/main/java/com/antithesis/ffi/internal/FfiHandler.java
@@ -6,8 +6,6 @@ import java.util.logging.Logger;
 
 public class FfiHandler implements OutputHandler {
 
-    private static long offset = -1;
-
     public static Optional<OutputHandler> get() {
         try {
             FfiWrapperJNI.loadLibrary();
@@ -26,29 +24,6 @@ public class FfiHandler implements OutputHandler {
     @Override
     public long random() {
         return FfiWrapperJNI.fuzz_get_random();
-    }
-
-    @Override
-    public long initializeModuleCoverage(long edgeCount, String symbolFilePath) {
-        if (offset != -1) {
-            // A Java application may not contain multiple "modules" in Antithesis terms.
-            throw new IllegalStateException("Antithesis Java instrumentation has already been initialized.");
-        }
-        if (edgeCount > Integer.MAX_VALUE || edgeCount < 1) {
-            throw new IllegalArgumentException("Antithesis Java instrumentation supports [1 ," + Integer.MAX_VALUE + "] edges");
-        }
-        offset = FfiWrapperJNI.init_coverage_module(edgeCount, symbolFilePath);
-        String msg = String.format("Initialized Java module at offset 0x%016x with %d edges; symbol file %s", offset, edgeCount, symbolFilePath);
-        // TODO: (@shomik) logger.info(msg); 
-        return offset;
-    }
-
-    @Override
-    public void notifyModuleEdge(long edgePlusModule) {
-        // Right now, the Java implementation defers completely to the native library. 
-        // See instrumentation.h to understand the logic here. The shim (i.e. StaticModule.java)
-        // is responsible for handling the return value.
-        FfiWrapperJNI.notify_coverage(edgePlusModule);
     }
 
 }

--- a/ffi/src/main/java/com/antithesis/ffi/internal/OutputHandler.java
+++ b/ffi/src/main/java/com/antithesis/ffi/internal/OutputHandler.java
@@ -4,9 +4,5 @@ public interface OutputHandler {
     void output(String value);
 
     long random();
-
-    long initializeModuleCoverage(long edgeCount, String symbolFilePath);
-
-    void notifyModuleEdge(long edgePlusModule);
 }
 

--- a/sdk/src/main/java/com/antithesis/sdk/internal/HandlerFactory.java
+++ b/sdk/src/main/java/com/antithesis/sdk/internal/HandlerFactory.java
@@ -62,14 +62,6 @@ public class HandlerFactory {
             return new Random().nextLong();
         }
 
-        @Override
-        public long initializeModuleCoverage(long edgeCount, String symbolFilePath) {
-            return edgeCount;
-        }
-
-        @Override
-        public void notifyModuleEdge(long edgePlusModule) {
-        }
     }
 
     private static class LocalHandler implements OutputHandler {
@@ -102,7 +94,6 @@ public class HandlerFactory {
                 writer.write("\n");
                 writer.flush();
             } catch (IOException ignored) {
-                // TODO (@shomik) logging
             }
         }
 
@@ -111,14 +102,6 @@ public class HandlerFactory {
             return new Random().nextLong();
         }
 
-        @Override
-        public long initializeModuleCoverage(long edgeCount, String symbolFilePath) {
-            return 0;
-        }
-
-        @Override
-        public void notifyModuleEdge(long edgePlusModule) {
-        }
     }
 
 }

--- a/sdk/src/main/java/com/antithesis/sdk/internal/Internal.java
+++ b/sdk/src/main/java/com/antithesis/sdk/internal/Internal.java
@@ -21,11 +21,4 @@ final public class Internal {
         }
     }
 
-    public static long dispatchInitializeModuleCoverage(long edgeCount, String symbolFilePath) {
-        return HandlerFactory.get().initializeModuleCoverage(edgeCount, symbolFilePath);
-    }
-
-    public static void dispatchNotifyModuleEdge(long edgePlusModule) {
-        HandlerFactory.get().notifyModuleEdge(edgePlusModule);
-    }
 }


### PR DESCRIPTION
Now that the FFI has been fully separated, we would like to fully separate concerns. 

These methods can still be accessed through the raw FFI and don't need to have wrappers exposed to SDK users. 