### PR TITLE
Fix output json format

### DIFF
--- a/ffi/build.gradle
+++ b/ffi/build.gradle
@@ -28,6 +28,7 @@ task buildFfiBridge(type: Exec) {
     }
 }
 compileJava.dependsOn buildFfiBridge
+compileTestJava.dependsOn buildFfiBridge
 
 task cleanFfiBridge(type: Exec) {
     workingDir projectDir

--- a/ffi/build.gradle
+++ b/ffi/build.gradle
@@ -44,8 +44,10 @@ jar {
     archiveAppendix = 'ffi'
     archiveBaseName = 'antithesis'
     manifest {
-        attributes 'Implementation-Title': 'Antithesis FFI for Java',
+        attributes 'Implementation-Title': 'Antithesis FFI for Java', // !! LOAD BEARING Title
                 'Implementation-Version': "${project.version}",
+                'Specification-Title': 'Antithesis SDK Protocol',
+                'Specification-Version': "${project.property('com.antithesis.sdk.protocol')}",
                 'Created-By': "Gradle ${gradle.gradleVersion}",
                 'Build-Jdk': "${System.properties['java.version']} (${System.properties['java.vendor']} ${System.properties['java.vm.version']})",
                 'Build-OS': "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"

--- a/ffi/src/main/java/com/antithesis/ffi/internal/FfiHandler.java
+++ b/ffi/src/main/java/com/antithesis/ffi/internal/FfiHandler.java
@@ -15,6 +15,7 @@ public class FfiHandler implements OutputHandler {
 
     @Override
     public void output(final String value) {
+        System.out.println(value);
         FfiWrapperJNI.fuzz_json_data(value, value.length());
         FfiWrapperJNI.fuzz_flush();
     }

--- a/ffi/src/main/java/com/antithesis/ffi/internal/FfiHandler.java
+++ b/ffi/src/main/java/com/antithesis/ffi/internal/FfiHandler.java
@@ -7,22 +7,10 @@ public class FfiHandler implements OutputHandler {
     private static long offset = -1;
 
     public static Optional<OutputHandler> get() {
-        if(FfiWrapperJNI.LOAD_LIBRARY_MARKER) {
+        if (FfiWrapperJNI.LOAD_LIBRARY_MARKER) {
             return Optional.of(new FfiHandler());
         }
         return Optional.empty();
-    }
-
-    @Override
-    public void output(final String value) {
-        System.out.println(value);
-        FfiWrapperJNI.fuzz_json_data(value, value.length());
-        FfiWrapperJNI.fuzz_flush();
-    }
-
-    @Override
-    public long random() {
-        return FfiWrapperJNI.fuzz_get_random();
     }
 
     public static long initializeModuleCoverage(long edgeCount, String symbolFilePath) {
@@ -41,6 +29,17 @@ public class FfiHandler implements OutputHandler {
 
     public static void notifyModuleEdge(long edgePlusModule) {
         FfiWrapperJNI.notify_coverage(edgePlusModule);
+    }
+
+    @Override
+    public void output(final String value) {
+        FfiWrapperJNI.fuzz_json_data(value, value.length());
+        FfiWrapperJNI.fuzz_flush();
+    }
+
+    @Override
+    public long random() {
+        return FfiWrapperJNI.fuzz_get_random();
     }
 
 }

--- a/ffi/swig/Makefile
+++ b/ffi/swig/Makefile
@@ -1,4 +1,8 @@
+
 build:
+	@# Verify dependencies are met
+	@command -v swig >/dev/null 2>&1 || { echo ""; echo >&2 "Error: swig is not installed."; echo ""; exit 1; }
+
 	# Generate java and .c files needed for JNI
 	swig -java -package com.antithesis.ffi.internal FfiWrapper.i
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,3 @@
 org.gradle.java.installations.auto-download=false
 version = 1.3.1
+com.antithesis.sdk.protocol = 1.0.0

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -72,6 +72,7 @@ test {
         showStandardStreams = true
     }
 }
+test.dependsOn jar
 
 tasks.named('test') {
     useJUnitPlatform()

--- a/sdk/src/main/java/com/antithesis/sdk/Random.java
+++ b/sdk/src/main/java/com/antithesis/sdk/Random.java
@@ -46,16 +46,19 @@ final public class Random {
      * @param <T>   Type of the array member items
      * @return Randomly selected item from the provided array.
      */
-    public static <T> Optional<T> randomChoice(T[] array) {
+    //public static <T> Optional<T> randomChoice(T[] array) {
+    public static <T> T randomChoice(T[] array) {
         if (array.length == 0) {
-            return Optional.empty();
+            return null; // Optional.empty();
         } else if (array.length == 1) {
-            return Optional.of(array[0]);
+            // return Optional.of(array[0]);
+            return array[0];
         } else {
             // Safety: Result of modulo is always less than the divisor
             // and will always fit into an integer
             int idx = (int) Long.remainderUnsigned(getRandom(), array.length);
-            return Optional.of(array[idx]);
+            // return Optional.of(array[idx]);
+            return array[idx];
         }
     }
 }

--- a/sdk/src/main/java/com/antithesis/sdk/Random.java
+++ b/sdk/src/main/java/com/antithesis/sdk/Random.java
@@ -2,7 +2,7 @@ package com.antithesis.sdk;
 
 import com.antithesis.sdk.internal.Internal;
 
-import java.util.Optional;
+import java.util.List;
 
 /**
  * The Random class provides methods that request both structured and unstructured randomness from the Antithesis environment.
@@ -42,23 +42,20 @@ final public class Random {
      * in a structured way enables it to provide more interesting
      * choices over time.
      *
-     * @param array An array of items to select from
-     * @param <T>   Type of the array member items
-     * @return Randomly selected item from the provided array.
+     * @param list An array of items to select from
+     * @param <T>  Type of the array member items
+     * @return Randomly selected item from the provided list.
      */
-    //public static <T> Optional<T> randomChoice(T[] array) {
-    public static <T> T randomChoice(T[] array) {
-        if (array.length == 0) {
-            return null; // Optional.empty();
-        } else if (array.length == 1) {
-            // return Optional.of(array[0]);
-            return array[0];
+    public static <T> T randomChoice(List<T> list) {
+        if (list.isEmpty()) {
+            return null;
+        } else if (list.size() == 1) {
+            return list.get(0);
         } else {
             // Safety: Result of modulo is always less than the divisor
             // and will always fit into an integer
-            int idx = (int) Long.remainderUnsigned(getRandom(), array.length);
-            // return Optional.of(array[idx]);
-            return array[idx];
+            int idx = (int) Long.remainderUnsigned(getRandom(), list.size());
+            return list.get(idx);
         }
     }
 }

--- a/sdk/src/main/java/com/antithesis/sdk/internal/Assertion.java
+++ b/sdk/src/main/java/com/antithesis/sdk/internal/Assertion.java
@@ -96,7 +96,10 @@ public final class Assertion {
     }
 
     private void emit() {
-        Internal.dispatchOutput(MAPPER.valueToTree(this));
+        ObjectNode assertionNode = MAPPER.createObjectNode();
+        assertionNode.put("antithesis_assert", MAPPER.valueToTree(this));
+
+        Internal.dispatchOutput(assertionNode);
     }
 
     private static class TrackingInfo {

--- a/sdk/src/main/java/com/antithesis/sdk/internal/HandlerFactory.java
+++ b/sdk/src/main/java/com/antithesis/sdk/internal/HandlerFactory.java
@@ -6,7 +6,6 @@ import com.antithesis.ffi.internal.OutputHandler;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Optional;
 import java.util.Random;
 
@@ -14,23 +13,14 @@ public class HandlerFactory {
 
     private final static boolean CATALOG_SENT = didLoadCatalog();
     // Will be initialized through the static 'HandlerFactory.get()' function
-    private static volatile OutputHandler HANDLER_INSTANCE = null;
-
-    private static volatile int RUN_COUNT = 0;
+    private static volatile OutputHandler HANDLER_INSTANCE;
 
     private static boolean didLoadCatalog() {
         String className = "com.antithesis.sdk.generated.AssertionCatalog";
-        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        if (classLoader == null) {
-            System.out.println("No classloader, can't make a catalogue!!");
-            return false;
-        }
         Class theClass = null;
-        boolean shouldInitialize = true;
         try {
-            theClass = Class.forName(className, shouldInitialize, classLoader);
+            theClass = Class.forName(className);
         } catch (Throwable ignored) {
-            ignored.printStackTrace();
         }
         return theClass != null;
     }
@@ -44,15 +34,12 @@ public class HandlerFactory {
 
     private static synchronized OutputHandler getInternal() {
         if (HANDLER_INSTANCE == null) {
-            System.out.println(Arrays.toString(new Throwable().getStackTrace()));
-            RUN_COUNT++;
             HANDLER_INSTANCE =
                     FfiHandler.get().orElseGet(() ->
                             LocalHandler.get().orElseGet(() ->
                                     NoOpHandler.get().orElseThrow(RuntimeException::new))
                     );
             Internal.dispatchVersionInfo();
-            System.out.println("Handler initialization block run: " + RUN_COUNT);
         }
         return HANDLER_INSTANCE;
     }

--- a/sdk/src/main/java/com/antithesis/sdk/internal/Internal.java
+++ b/sdk/src/main/java/com/antithesis/sdk/internal/Internal.java
@@ -10,8 +10,6 @@ final public class Internal {
     private static final ObjectMapper MAPPER = new ObjectMapper();
     private static final String SDK_VERSION = loadSDKVersion();
 
-    private static boolean VERSION_INFO_SENT = false;
-
     private static final String PROTOCOL_VERSION = "1.0.0";
 
     private static String loadSDKVersion() {
@@ -19,8 +17,6 @@ final public class Internal {
     }
 
     public static void dispatchVersionInfo() {
-        System.out.println("Trying to send version info, sent status: " + VERSION_INFO_SENT);
-
         ObjectNode antithesisLanguageInfo = MAPPER.createObjectNode();
         antithesisLanguageInfo.put("name", "Java");
         antithesisLanguageInfo.put("version", System.getProperty("java.version"));
@@ -33,9 +29,6 @@ final public class Internal {
         ObjectNode antithesisSDKInfo = MAPPER.createObjectNode();
         antithesisSDKInfo.put("antithesis_sdk", antithesisVersionInfo);
         dispatchOutput(antithesisSDKInfo);
-
-        VERSION_INFO_SENT = true;
-        System.out.println("Sent version info, new sent status: " + VERSION_INFO_SENT);
     }
 
     public static long dispatchRandom() {

--- a/sdk/src/main/java/com/antithesis/sdk/internal/Internal.java
+++ b/sdk/src/main/java/com/antithesis/sdk/internal/Internal.java
@@ -8,6 +8,35 @@ import java.io.IOException;
 final public class Internal {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final String SDK_VERSION = loadSDKVersion();
+
+    private static boolean VERSION_INFO_SENT = false;
+
+    private static final String PROTOCOL_VERSION = "1.0.0";
+
+    private static String loadSDKVersion() {
+        return "1.3.1";
+    }
+
+    public static void dispatchVersionInfo() {
+        System.out.println("Trying to send version info, sent status: " + VERSION_INFO_SENT);
+
+        ObjectNode antithesisLanguageInfo = MAPPER.createObjectNode();
+        antithesisLanguageInfo.put("name", "Java");
+        antithesisLanguageInfo.put("version", System.getProperty("java.version"));
+
+        ObjectNode antithesisVersionInfo = MAPPER.createObjectNode();
+        antithesisVersionInfo.put("language", antithesisLanguageInfo);
+        antithesisVersionInfo.put("sdk_version", loadSDKVersion());
+        antithesisVersionInfo.put("protocol_version", PROTOCOL_VERSION);
+
+        ObjectNode antithesisSDKInfo = MAPPER.createObjectNode();
+        antithesisSDKInfo.put("antithesis_sdk", antithesisVersionInfo);
+        dispatchOutput(antithesisSDKInfo);
+
+        VERSION_INFO_SENT = true;
+        System.out.println("Sent version info, new sent status: " + VERSION_INFO_SENT);
+    }
 
     public static long dispatchRandom() {
         return HandlerFactory.get().random();

--- a/sdk/src/main/java/com/antithesis/sdk/internal/Internal.java
+++ b/sdk/src/main/java/com/antithesis/sdk/internal/Internal.java
@@ -41,6 +41,7 @@ final public class Internal {
                         if (attributes.containsKey(aProtocol)) {
                             protocolVersion = attributes.getValue(aProtocol);
                         }
+                        break;  // no sense in looking any further
                     }
                 }
             }

--- a/sdk/src/main/java/com/antithesis/sdk/internal/Internal.java
+++ b/sdk/src/main/java/com/antithesis/sdk/internal/Internal.java
@@ -4,6 +4,10 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 
 import java.io.IOException;
+import java.net.URL;
+import java.util.Enumeration;
+import java.util.jar.Attributes;
+import java.util.jar.Manifest;
 
 final public class Internal {
 
@@ -13,7 +17,28 @@ final public class Internal {
     private static final String PROTOCOL_VERSION = "1.0.0";
 
     private static String loadSDKVersion() {
-        return "1.3.1";
+        try {
+            Enumeration<URL> manifests = Internal.class.getClassLoader().getResources("META-INF/MANIFEST.MF");
+            while(manifests.hasMoreElements()) {
+                Manifest manifest = new Manifest(manifests.nextElement().openStream());
+                Attributes attributes = manifest.getMainAttributes();
+
+                Attributes.Name aName = new Attributes.Name("Implementation-Title");
+                Attributes.Name aVersion = new Attributes.Name("Implementation-Version");
+
+                if(attributes.containsKey(aName)) {
+                    // Antithesis FFI and SDK are guaranteed to share the same version
+                    if(attributes.getValue(aName).equals("Antithesis FFI for Java")) {
+                        if (attributes.containsKey(aVersion)) {
+                            return attributes.getValue(aVersion);
+                        }
+                    }
+                }
+            }
+        } catch (Exception e) {
+            return "0.0.0";
+        }
+        return "0.0.0";
     }
 
     public static void dispatchVersionInfo() {
@@ -23,7 +48,7 @@ final public class Internal {
 
         ObjectNode antithesisVersionInfo = MAPPER.createObjectNode();
         antithesisVersionInfo.put("language", antithesisLanguageInfo);
-        antithesisVersionInfo.put("sdk_version", loadSDKVersion());
+        antithesisVersionInfo.put("sdk_version", SDK_VERSION);
         antithesisVersionInfo.put("protocol_version", PROTOCOL_VERSION);
 
         ObjectNode antithesisSDKInfo = MAPPER.createObjectNode();

--- a/sdk/src/test/java/com/antithesis/sdk/RandomTest.java
+++ b/sdk/src/test/java/com/antithesis/sdk/RandomTest.java
@@ -12,13 +12,13 @@ public class RandomTest {
     @Test
     void randomNoChoice() {
         String[] arr = {};
-        assertEquals(Random.randomChoice(arr), Optional.empty());
+        assertEquals(Random.randomChoice(arr), null);
     }
 
     @Test
     void randomOneChoice() {
         String[] arr = {"ABc"};
-        assertEquals(Random.randomChoice(arr), Optional.of("ABc"));
+        assertEquals(Random.randomChoice(arr), "ABc");
     }
 
     @Test
@@ -34,10 +34,10 @@ public class RandomTest {
         Character[] all_keys = counted_items.keySet().toArray(new Character[0]);
         assertEquals(counted_items.size(), all_keys.length);
         for (int i = 0; i < 25; i++) {
-            Optional<Character> rc = Random.randomChoice(all_keys);
-            if (rc.isPresent()) {
-                Character choice = rc.get();
-                counted_items.computeIfPresent(choice, (key, val) -> val + 1);
+            Character rc = Random.randomChoice(all_keys);
+            if (rc != null) {
+                Character choice = rc;
+                counted_items.compute(choice, (key, val) -> val + 1);
             }
         }
         counted_items.forEach((key, val) -> assertNotEquals(val, 0, String.format("Did not produce the choice: %c", key)));

--- a/sdk/src/test/java/com/antithesis/sdk/RandomTest.java
+++ b/sdk/src/test/java/com/antithesis/sdk/RandomTest.java
@@ -2,23 +2,27 @@ package com.antithesis.sdk;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Optional;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Vector;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 public class RandomTest {
     @Test
     void randomNoChoice() {
-        String[] arr = {};
-        assertEquals(Random.randomChoice(arr), null);
+        List<String> list = new ArrayList<>();
+        assertNull(Random.randomChoice(list));
     }
 
     @Test
     void randomOneChoice() {
-        String[] arr = {"ABc"};
-        assertEquals(Random.randomChoice(arr), "ABc");
+        List<String> list = new LinkedList<String>();
+        list.add("ABc");
+        assertEquals(Random.randomChoice(list), "ABc");
     }
 
     @Test
@@ -31,13 +35,12 @@ public class RandomTest {
         counted_items.put('c', 0);
         counted_items.put('d', 0);
 
-        Character[] all_keys = counted_items.keySet().toArray(new Character[0]);
-        assertEquals(counted_items.size(), all_keys.length);
+        List<Character> all_keys = new Vector<>(counted_items.keySet());
+        assertEquals(counted_items.size(), all_keys.size());
         for (int i = 0; i < 25; i++) {
-            Character rc = Random.randomChoice(all_keys);
-            if (rc != null) {
-                Character choice = rc;
-                counted_items.compute(choice, (key, val) -> val + 1);
+            Character choice = Random.randomChoice(all_keys);
+            if (choice != null) {
+                counted_items.computeIfPresent(choice, (key, val) -> val + 1);
             }
         }
         counted_items.forEach((key, val) -> assertNotEquals(val, 0, String.format("Did not produce the choice: %c", key)));


### PR DESCRIPTION
Ensure FFI Handler is loaded if possible, and only loaded once
Ensure that the `antithesis_sdk` info is created and 'output' once an OutputHandler is selected
Adds SDK Protocol to mainAttributes in FFI.jar manifest
Updated the `randomChoice()` signature to return `T` rather than `Optional<T>`
Ensure sure that `make` has access to `swig` before attempting to use it, and advises if `swig` is not available
Ensure that `antithesis_assert` labels are associated with all Assertion output messages