### PR TITLE
Expose com.fasterxml.jackson.core:jackson-databind dependency.

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -81,7 +81,7 @@ repositories {
 }
 
 dependencies {
-    implementation 'com.fasterxml.jackson.core:jackson-databind:2.2.3'
+    api 'com.fasterxml.jackson.core:jackson-databind:2.19.0'
 
     if (file("libs/antithesis-ffi-${project.version}.jar").isFile()) {
         implementation(files("libs/antithesis-ffi-${project.version}.jar"))
@@ -95,7 +95,6 @@ dependencies {
     // Use JUnit Jupiter for testing.
     testImplementation 'org.junit.jupiter:junit-jupiter:5.9.3'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testImplementation 'com.fasterxml.jackson.core:jackson-databind:2.2.3'
 
     testCompileOnly 'org.projectlombok:lombok:1.18.34'
     testAnnotationProcessor 'org.projectlombok:lombok:1.18.34'


### PR DESCRIPTION
The [Assert](https://antithesis.com/docs/generated/sdk/java/com/antithesis/sdk/Assert.html) APIs take `ObjectNode`  as input, which is part of `jackson-databind` package. So we need to expose this dependency. Otherwise, client applications will fail to compile: `Cannot access class 'ObjectNode'.` 

Also bump `jackson-databind` package version. 

